### PR TITLE
TEC-11009 Add missing properties to Maven config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,37 @@
     <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>https://raw.githubusercontent.com/ebx/ebx-unixtime-sdk/master/LICENSE</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:https://github.com/ebx/ebx-unixtime-sdk</connection>
+    <url>https://github.com/ebx/ebx-unixtime-sdk</url>
+  </scm>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+
+  <developers>
+    <developer>
+      <name>Echobox</name>
+      <organizationUrl>http://www.echobox.com</organizationUrl>
+    </developer>
+  </developers>
+
   <dependencies>
   </dependencies>
 


### PR DESCRIPTION
## [TEC-11009](https://echobox.atlassian.net/browse/TEC-11009)

### Spec 
Not Applicable.

### Priority
Normal.

### Description of Changes
Added missing propeties to `pom.xml`.

### Documentation
Not Applicable.

### Risks & Impacts
None.

### Security
None.

### Testing
Verify if is correctly setup after deployment.

### Deployment Considerations
None.