### PR TITLE
Release 2.0.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to ebx-linkedin-sdk
+# Contributing to ebx-unixtime-sdk
 
-Contributing code is an essential part of open source and we try to make this as easy as possible. There are several ways you can contribute to ebx-linkedin-sdk.  Here are some guidelines for creating new issues and sending us pull requests. Please read them carefully before contributing.
+Contributing code is an essential part of open source and we try to make this as easy as possible. There are several ways you can contribute to ebx-unixtime-sdk.  Here are some guidelines for creating new issues and sending us pull requests. Please read them carefully before contributing.
 
 ## How to create a new issue
 
@@ -18,8 +18,8 @@ We like new issues and are very keen to hear your problems, ideas and proposals.
 Pull requests (PR) are a very important way to contribute code to the library. We have guidelines for sending us a PR, because changes to the source code are even more fundamental than sending a new issue. This is an overview of our prerequisites.
 
 **PR checklist:**
-* Please ensure you have an associated [github issue](https://github.com/ebx/ebx-linkedin-sdk/issues) to hand, this needs to be included in the PR. If a suitable issue doesn't already exist feel free to create one, as described above.
-* The code must be formatted with our code formatter (have a look at the [CodeStyle folder](https://github.com/ebx/ebx-linkedin-sdk/tree/master/CodeStyle)). If you perform a local *mvn verify* before creating the PR your changes will already be getting validated for style.
+* Please ensure you have an associated [github issue](https://github.com/ebx/ebx-unixtime-sdk/issues) to hand, this needs to be included in the PR. If a suitable issue doesn't already exist feel free to create one, as described above.
+* The code must be formatted with our code formatter (have a look at the [CodeStyle folder](https://github.com/ebx/ebx-unixtime-sdk/tree/master/CodeStyle)). If you perform a local *mvn verify* before creating the PR your changes will already be getting validated for style.
 * The code layout should conform to our general design standards (if you feel it's necessary to go against the grain, please ask us first!).
 * You should complete the PR template and please format your PR title as follows:
 
@@ -33,5 +33,5 @@ Pull requests (PR) are a very important way to contribute code to the library. W
 * Junit tests required for any functional change must be included.
 * The pull request should be targetted at the `dev` branch. If you raise it against `master` the PR will fail to build.
 * Please try to keep PR commits in a logical order incase we need to review each commit seperately, but generally speaking the fewer commits the better.
-* Your PR will have to build succesfully against our CI (we use [Travis CI](https://travis-ci.org/ebx/ebx-linkedin-sdk)).
+* Your PR will have to build succesfully against our CI (we use [Travis CI](https://travis-ci.org/ebx/ebx-unixtime-sdk)).
 * **Important Note**: If your PR contains breaking changes you must include a MAJOR version bump in the PR.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Maven Central](https://img.shields.io/maven-central/v/com.echobox/ebx-unixtime-sdk.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.echobox%22%20AND%20a:%22ebx-unixtime-sdk%22) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://raw.githubusercontent.com/ebx/ebx-unixtime-sdk/master/LICENSE) [![Build Status](https://travis-ci.org/ebx/ebx-unixtime-sdk.svg?branch=dev)](https://travis-ci.org/ebx/ebx-unixtime-sdk)
 # ebx-unixtime-sdk
 
 A simple reusable implementation of a unix time construct.

--- a/pom.xml
+++ b/pom.xml
@@ -106,8 +106,7 @@
             <configuration>
               <configLocation>CodeStyle/checkstyle.xml</configLocation>
               <consoleOutput>true</consoleOutput>
-              <failsOnError>false</failsOnError>
-              <failOnViolation>false</failOnViolation>
+              <failsOnError>true</failsOnError>
               <includeTestSourceDirectory>true</includeTestSourceDirectory>
               <propertyExpansion>basedir=${project.basedir}</propertyExpansion>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <name>ebx-unixtime-sdk</name>
+  <description>ebx-unixtime-sdk is a simple reusable implementation of a unix time construct.</description>
+  <url>https://github.com/ebx/ebx-unixtime-sdk</url>
+
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.echobox</groupId>
   <artifactId>ebx-unixtime-sdk</artifactId>
@@ -12,7 +17,6 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 
   <licenses>


### PR DESCRIPTION
### Description of Changes

After some cleanup and getting the CI working correctly we're ready to release version 2.0.0. It would have been version 1.1.0 if it had not been for the breaking change in unixtime formatting.

### Documentation

NA

### Risks & Impacts

Release only.

### Testing

Tests have been added as part of this release as well as it being in active production use elsewhere.

## Final Checklist

Please tick once completed.

- [x] Build passes.
- [x] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [x] Change log has been updated.